### PR TITLE
SIP-DoS uses '--tn' flag for 'target network' (previously 'destination ip')

### DIFF
--- a/mr.sip.py
+++ b/mr.sip.py
@@ -104,7 +104,7 @@ parser.add_option("--ds", "--dos-simulator", action="store_true", dest="dos_simu
 
 NES_USAGE = "python mr.sip.py --ns --tn <IP/IP-range/network> --dp=5060"
 ENUM_USAGE = "python mr.sip.py --se --dp=5060 --fu=fromUser.txt"
-DAS_USAGE = "python mr.sip.py --ds -dm=invite -c <packet_count> --di=<target_server_IP> --dp=<server_port> -r --to=toUser.txt --fu=fromUser.txt --ua=userAgent.txt --su=spUser.txt"
+DAS_USAGE = "python mr.sip.py --ds -dm=invite -c <packet_count> --tn=<target_server_IP> --dp=<server_port> -r --to=toUser.txt --fu=fromUser.txt --ua=userAgent.txt --su=spUser.txt"
 
 group_NES_usage = OptionGroup(parser, "SIP-NES Usage", NES_USAGE) # "IP range format: 192.168.1.10-192.168.1.20. Output also written to ip_list.txt."
 group_ENUM_usage = OptionGroup(parser, "SIP-ENUM Usage", ENUM_USAGE) # "It reads from ip_list.txt. You can also give the target by using --di=<target_server_IP>."        
@@ -121,7 +121,7 @@ group.add_option("-i", "--ip-save-list", dest="ip_list", default="ip_list.txt", 
 group.add_option("--dm", "--dos-method", dest="dos_method", default="register", help="DoS packet type selection. options, invite, register, sip-invite, subscribe, cancel, bye or other custom method file name.")
 group.add_option("-c", "--count", type="int", dest="counter", default="99999999", help="Counter for how many messages to send. If not specified, default is flood.")
 group.add_option("-l", "--lib", action="store_true", dest="library", default=False, help="Use Socket library (no spoofing), default is Scapy")
-group.add_option("--di", "--destination-ip", dest="dest_ip", help="Destination SIP server IP address.")
+# group.add_option("--di", "--destination-ip", dest="dest_ip", help="Destination SIP server IP address.")
 group.add_option("--dp", "--destination-port", dest="dest_port", default=5060, help="Destination SIP server port number. Default is 5060.")
 group.add_option("-r", "--random", action="store_true", dest="random", default=False, help="Spoof IP addresses randomly.")
 group.add_option("-m", "--manual", action="store_true", dest="manual", default=False, help="Spoof IP addresses manually. If you choose manual IP usage, you have to specify a IP list via --manual-ip-list parameter.")
@@ -346,7 +346,7 @@ def dosSmilator():
          spUser = random.choice([line.rstrip('\n') for line in open(options.sp_user)])
          userAgent = random.choice([line.rstrip('\n') for line in open(options.user_agent)])
          
-         pkt= IP(dst=options.dest_ip)
+         pkt= IP(dst=options.target_network)
          client = pkt.src
          
          if options.random and not options.library:
@@ -359,7 +359,7 @@ def dosSmilator():
          if options.library:
                send_protocol = "socket"
                
-         sip = sip_packet.sip_packet(str(options.dos_method), str(options.dest_ip), str(options.dest_port), str(client), str(fromUser), str(toUser), str(userAgent), str(spUser), send_protocol)
+         sip = sip_packet.sip_packet(str(options.dos_method), str(options.target_network), str(options.dest_port), str(client), str(fromUser), str(toUser), str(userAgent), str(spUser), send_protocol)
          sip.generate_packet()
          i += 1
          utilities.printProgressBar(i,int(options.counter),"Progress: ")
@@ -368,7 +368,7 @@ def dosSmilator():
          print ("Exiting traffic generation...")
          raise SystemExit
    
-   print ("\033[31m[!] DoS simulation finished and {0} packet sent to {1}...\033[0m".format(str(i),str(options.dest_ip)))
+   print ("\033[31m[!] DoS simulation finished and {0} packet sent to {1}...\033[0m".format(str(i),str(options.target_network)))
    utilities.promisc("off",conf.iface)
 
 

--- a/mr.sip.py
+++ b/mr.sip.py
@@ -118,7 +118,7 @@ parser.add_option_group(group_DAS_usage)
 group = OptionGroup(parser, "Parameters")
 group.add_option("--tn", "--target-network", dest="target_network", help="Target network range to scan.")
 group.add_option("-i", "--ip-save-list", dest="ip_list", default="ip_list.txt", help="Output file location to save live IP address.\n Default location is inside application folder ip_list.txt.")
-group.add_option("--dm", "--dos-method", dest="dos_method", default="invite", help="DoS packet type selection. options, invite, register, sip-invite, subscribe, cancel, bye or other custom method file name.")
+group.add_option("--dm", "--dos-method", dest="dos_method", default="register", help="DoS packet type selection. options, invite, register, sip-invite, subscribe, cancel, bye or other custom method file name.")
 group.add_option("-c", "--count", type="int", dest="counter", default="99999999", help="Counter for how many messages to send. If not specified, default is flood.")
 group.add_option("-l", "--lib", action="store_true", dest="library", default=False, help="Use Socket library (no spoofing), default is Scapy")
 group.add_option("--di", "--destination-ip", dest="dest_ip", help="Destination SIP server IP address.")
@@ -311,7 +311,7 @@ def sipEnumerator():
    counter = 0  # extension counter
 
    for threadName in threadList:
-      thread = ThreadSIPENUM(threadID, threadName, content[0].strip(), options.dest_port, client_ip)
+      thread = ThreadSIPENUM(threadID, threadName, options.dos_method, content[0].strip(), options.dest_port, client_ip)
       thread.start()  # invoke the 'run()' function in the class
       threads.append(thread)
       threadID += 1
@@ -432,11 +432,12 @@ class ThreadSIPNES(threading.Thread):
 
 # Thread object for SIP-ENUM
 class ThreadSIPENUM(threading.Thread):
-   def __init__(self, threadID, name, serverIP, dest_port, client_ip):
+   def __init__(self, threadID, name, option, serverIP, dest_port, client_ip):
       threading.Thread.__init__(self)
       self.threadID = threadID
       self.name = name
 
+      self.option = option
       self.serverIP = serverIP
       self.dest_port = dest_port
       self.client_ip = client_ip
@@ -453,7 +454,7 @@ class ThreadSIPENUM(threading.Thread):
             user_id = workQueue.get()  # get host
             queueLock.release()  # when host is acquired, release the lock
 
-            sip = sip_packet.sip_packet("register", self.serverIP, self.dest_port, self.client_ip, from_user = user_id.strip(),to_user = user_id.strip(),protocol="socket", wait=True)
+            sip = sip_packet.sip_packet(self.option, self.serverIP, self.dest_port, self.client_ip, from_user = user_id.strip(),to_user = user_id.strip(),protocol="socket", wait=True)
             result = sip.generate_packet()
             
             if result["status"]:

--- a/mr.sip.py
+++ b/mr.sip.py
@@ -235,7 +235,7 @@ def networkScanner():
       counter = 0
 
       for threadName in threadList:
-         thread = ThreadSIPNES(threadID, threadName, options.dest_port, client_ip)
+         thread = ThreadSIPNES(threadID, threadName, options.dos_method, options.dest_port, client_ip)
          thread.start()  # invoke the 'run()' function in the class
          threads.append(thread)
          threadID += 1
@@ -398,11 +398,12 @@ def printResult(result,target):
 
 # Thread object for SIP-NES function
 class ThreadSIPNES(threading.Thread):
-   def __init__(self, threadID, name, dest_port, client_ip):
+   def __init__(self, threadID, name, option, dest_port, client_ip):
       threading.Thread.__init__(self)  # inherit the constructor
       self.threadID = threadID
       self.name = name
 
+      self.option = option
       self.dest_port = dest_port
       self.client_ip = client_ip
    
@@ -418,7 +419,7 @@ class ThreadSIPNES(threading.Thread):
             host = workQueue.get()  # get host
             queueLock.release()  # when host is acquired, release the lock
 
-            sip = sip_packet.sip_packet("options", host, self.dest_port, self.client_ip, protocol="socket", wait=True)  # set options
+            sip = sip_packet.sip_packet(self.option, host, self.dest_port, self.client_ip, protocol="socket", wait=True)  # set options
             result = sip.generate_packet()  # generate packet.
 
             if result["status"]: 


### PR DESCRIPTION
SIP-NES uses `--tn` flag for `target network`
however, SIP-DAS, for the same parameter, uses `--di` flag. Now `--di` flag option is commented out. SIP-DAS is using `--tn` flag as standard.

I could not find no such usage for SIP-ENUM. So I did not change anything in SIP-ENUM.